### PR TITLE
fix(webpack) watch complains about process.browser

### DIFF
--- a/webpack-shared-config.js
+++ b/webpack-shared-config.js
@@ -87,7 +87,7 @@ module.exports = (minimize, analyzeBundle) => {
                 }),
             !minimize
                 && new ProvidePlugin({
-                    process: 'process/browser'
+                    process: require.resolve('process/browser')
                 })
         ].filter(Boolean)
     };


### PR DESCRIPTION
In your version, probably because the multiple extensions, webpack errors in resolving process.browser. This pr fixes it.