### PR TITLE
fix(jitsiConference): check room before starting a P2P session

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3389,6 +3389,11 @@ JitsiConference.prototype._startP2PSession = function(remoteJid) {
         return;
     }
 
+    if (!this.room) {
+        logger.error('The conference has been left.');
+        return;
+    }
+
     this.isP2PConnectionInterrupted = false;
     this.p2pJingleSession
         = this.xmpp.connection.jingle.newP2PJingleSession(


### PR DESCRIPTION
The error `Strophe: TypeError: Cannot read properties of null (reading 'myroomjid')` appears sporadically.

Probably this error is caused by calling [`_startP2PSession`](https://github.com/lynoapp/lib-jitsi-meet/blob/1a296fb79b8bddec1ea7b8b8be476db32f185e21/JitsiConference.js#L3384) through [`setTimeout` ](https://github.com/lynoapp/lib-jitsi-meet/blob/1a296fb79b8bddec1ea7b8b8be476db32f185e21/JitsiConference.js#L3505)after the conference was left. To prevent this the presence of `room` is checked before executing the body of `_startP2PSession`.